### PR TITLE
Import Order

### DIFF
--- a/base/rules/imports.js
+++ b/base/rules/imports.js
@@ -80,7 +80,8 @@ module.exports = {
     // ensures we follow a defined sort order
     // https://github.com/jfmengels/eslint-plugin-import-order/blob/master/docs/rules/import-order.md
     "import-order/import-order": [2, {
-      "order": ["builtin", "external", "parent", "sibling", "index"]
+      // include all ? : "builtin", "external", "parent", "sibling", "index" 
+      "order": ["builtin", "external"]
     }],
   },
 };

--- a/base/rules/imports.js
+++ b/base/rules/imports.js
@@ -76,5 +76,11 @@ module.exports = {
     // ensure imports point to files/modules that can be resolved
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
     'import/no-unresolved': [2, { commonjs: true }],
+
+    // ensures we follow a defined sort order
+    // https://github.com/jfmengels/eslint-plugin-import-order/blob/master/docs/rules/import-order.md
+    "import-order/import-order": [2, {
+      "order": ["builtin", "external", "parent", "sibling", "index"]
+    }],
   },
 };


### PR DESCRIPTION
# Proposal:
I am proposing adding this in to help with our import order requirements or switching to follow this instead of our desired (see below) order.

Support for linting the order of imports. The order is as follows:

1. Built-ins (e.g. `fs`)
2. External (e.g. `react`)

[Docs](https://github.com/jfmengels/eslint-plugin-import-order/blob/master/docs/rules/import-order.md)

This doesn't support our desired order:

- All node core modules (fs, path, etc)
- 3rd party packages/modules (react, redux, etc)
- Internal modules including configuration files, constants, utilities
- Actions
- Components - destructured imports first followed by the rest

but this is a step in the right direction. 