### PR TITLE
bugfix/sass-rule-mixin-name

### DIFF
--- a/scss/sass-lint.yaml
+++ b/scss/sass-lint.yaml
@@ -350,5 +350,5 @@ rules:
   mixin-name-format:
   - 2
   -
+    convention: camelcase
     allow-leading-underscore: false
-    convention: camelCase


### PR DESCRIPTION
* Fix for `mixin-name-format` rule parameter from `camelCase` to `camelcase`