### PR TITLE
Proposed changes | react/jsx-boolean-value

### DIFF
--- a/js/base/rules/best-practices.js
+++ b/js/base/rules/best-practices.js
@@ -210,7 +210,7 @@ module.exports = {
 
     'valid-jsdoc': [2, {
       prefer: {
-        'return': 'returns',
+        'return': 'return',
       },
       preferType: {
         'object': 'Object',

--- a/js/react/rules/react.js
+++ b/js/react/rules/react.js
@@ -24,7 +24,7 @@ module.exports = {
 
     // Enforce boolean attributes notation in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-    'react/jsx-boolean-value': [2, 'never'],
+    'react/jsx-boolean-value': [1, 'never'],
 
     // Validate closing bracket location in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md

--- a/js/react/rules/react.js
+++ b/js/react/rules/react.js
@@ -24,7 +24,7 @@ module.exports = {
 
     // Enforce boolean attributes notation in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-    'react/jsx-boolean-value': [2, 'always'],
+    'react/jsx-boolean-value': [2, 'never'],
 
     // Validate closing bracket location in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md


### PR DESCRIPTION
# Change Notes
## Proposal 1:
Proposing we change `valid-jsdoc` from `returns` to `return`. Reasoning here, is phpstorm by default generates all the necessary jsdoc code as `@return` and rather than have to fight against the utilities we already have to reformat all of the generated code to conform to `returns` I'm proposing we leave the autogenerated code alone in favor of `@return`.
**Edit - the updates in master support both return or returns - so this is no longer required.**

## Proposal 2: 
`react/jsx-boolean-value` - switch this to "never" so we can compose components in the following ways without issues:
`<div itemScope />` OR `<button disabled />` OR `<button disabled={true} />`