### PR TITLE
Fix React Router Link element linting

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neighborhoods",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Neighborhoods.com Javascript Style Guide & Linting Rules",
   "keywords": [
     "nhds",

--- a/js/react/rules/react-a11y.js
+++ b/js/react/rules/react-a11y.js
@@ -43,10 +43,11 @@ module.exports = {
       components: ['']
     }],
 
-    // disallow href "#"
+    // disallow href "#" and enforce link best practices
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
     'jsx-a11y/anchor-is-valid': [2, {
-      components: ['Link', 'Anchor', 'a']
+      components: ['Link', 'Anchor', 'a'],
+      specialLink: ['to']
     }],
 
     // require HTML elements to have a "lang" prop


### PR DESCRIPTION
## Change Notes
- Added "to" to link linting rule because it replaces 'href' on Link elements

