### PR TITLE
Remove Linting Requirement of 'No Braces when Possible' on Arrow Func…

### DIFF
--- a/js/base/rules/es6.js
+++ b/js/base/rules/es6.js
@@ -12,10 +12,6 @@ module.exports = {
   },
 
   rules: {
-    // enforces no braces where they can be omitted
-    // http://eslint.org/docs/rules/arrow-body-style
-    'arrow-body-style': [2, 'as-needed'],
-
     // require parens in arrow function arguments
     // http://eslint.org/docs/rules/arrow-parens
     'arrow-parens': 2,


### PR DESCRIPTION
## Change Notes
- Removed Linting Requirement of 'No Braces when Possible' on Arrow Functions

This now allows either configuration, braces or not. 

The reason for this change (as discussed at the Facade meeting) is to allow increased ease-of-debugging at the developer's discretion. Compiled code is the same for braced or unbraced arrow functions, adding no bloat to the codebase but reducing debug time depending on developer workflow.

![image](https://user-images.githubusercontent.com/18424087/70921578-3037e800-1fea-11ea-93aa-4f7ba144dd70.png)


## Jira Issues
https://55places.atlassian.net/browse/FENH-1636
